### PR TITLE
Fix BinaryGetResponse to return cached value, make HTTP auth optional

### DIFF
--- a/src/main/java/org/couchbase/mock/CouchbaseMock.java
+++ b/src/main/java/org/couchbase/mock/CouchbaseMock.java
@@ -133,6 +133,13 @@ public class CouchbaseMock implements HttpRequestHandler, Runnable {
 	this(hostname, port, numNodes, numVBuckets, BucketType.BASE);
     }
 
+    /**
+     * The port of the http server providing the REST interface.
+     */
+    public int getHttpPort() {
+        return httpServer.getPort();
+    }
+
     public Credentials getRequiredHttpAuthorization() {
         return requiredHttpAuthorization;
     }

--- a/src/main/java/org/couchbase/mock/memcached/MemcachedServer.java
+++ b/src/main/java/org/couchbase/mock/memcached/MemcachedServer.java
@@ -179,7 +179,7 @@ public class MemcachedServer implements Runnable, BinaryProtocolHandler {
                     MemcachedConnection client = (MemcachedConnection) key.attachment();
 
                     if (client != null) {
-                        assert key.isAcceptable();
+                        // assert key.isAcceptable();
 
                         try {
 

--- a/src/main/java/org/couchbase/mock/memcached/protocol/BinaryGetResponse.java
+++ b/src/main/java/org/couchbase/mock/memcached/protocol/BinaryGetResponse.java
@@ -16,6 +16,7 @@
  */
 package org.couchbase.mock.memcached.protocol;
 
+import java.nio.ByteBuffer;
 import org.couchbase.mock.memcached.Item;
 
 /**
@@ -28,10 +29,16 @@ public class BinaryGetResponse extends BinaryResponse {
     }
 
     public BinaryGetResponse(BinaryCommand command, Item item) {
-        super(command, ErrorCode.NOT_SUPPORTED);
+        super(create(command, item));
     }
-//    public BinaryResponse(BinaryCommand command, Item item) {
-//        create(command, item);
-//    }
+
+    private static ByteBuffer create(BinaryCommand command, Item item) {
+        final ByteBuffer message = BinaryResponse.create(command, ErrorCode.SUCCESS,
+                4 /* flags */, 0, item.getValue().length, 0);
+        message.putInt(item.getFlags());
+        message.put(item.getValue());
+        message.rewind();
+        return message;
+    }
 
 }

--- a/src/main/java/org/couchbase/mock/memcached/protocol/BinaryResponse.java
+++ b/src/main/java/org/couchbase/mock/memcached/protocol/BinaryResponse.java
@@ -27,27 +27,36 @@ public class BinaryResponse {
     private static final byte DATATYPE = 0;
     protected final ByteBuffer buffer;
 
+    protected BinaryResponse(final ByteBuffer buffer) {
+        this.buffer = buffer;
+    }
+
     protected BinaryResponse(BinaryCommand command, ErrorCode errorCode, int extlen, int keylen, int datalen, long cas) {
-        buffer = create(command, errorCode, extlen, keylen, datalen, cas);
+        buffer = createAndRewind(command, errorCode, extlen, keylen, datalen, cas);
     }
 
     public BinaryResponse(BinaryCommand command, ErrorCode errorCode) {
-        buffer = create(command, errorCode, 0, 0, 0, 0);
+        buffer = createAndRewind(command, errorCode, 0, 0, 0, 0);
     }
 
-    private ByteBuffer create(BinaryCommand command, ErrorCode errorCode, int extlen, int keylen, int datalen, long cas) {
-       ByteBuffer message = ByteBuffer.allocate(24 + extlen + keylen + datalen);
-       message.put(MAGIC);
-       message.put(command.getComCode().cc());
-       message.putShort((short)keylen);
-       message.put((byte)extlen);
-       message.put(DATATYPE);
-       message.putShort(errorCode.value());
-       message.putInt(datalen + keylen + extlen);
-       message.putInt(command.getOpaque());
-       message.putLong(cas);
+    static ByteBuffer createAndRewind(BinaryCommand command, ErrorCode errorCode, int extlen, int keylen, int datalen, long cas) {
+       ByteBuffer message = create(command, errorCode, extlen, keylen, datalen, cas);
        message.rewind();
        return message;
+    }
+
+    static ByteBuffer create(BinaryCommand command, ErrorCode errorCode, int extlen, int keylen, int datalen, long cas) {
+        ByteBuffer message = ByteBuffer.allocate(24 + extlen + keylen + datalen);
+           message.put(MAGIC);
+           message.put(command.getComCode().cc());
+           message.putShort((short)keylen);
+           message.put((byte)extlen);
+           message.put(DATATYPE);
+           message.putShort(errorCode.value());
+           message.putInt(datalen + keylen + extlen);
+           message.putInt(command.getOpaque());
+           message.putLong(cas);
+        return message;
     }
 
     public ByteBuffer getBuffer() {


### PR DESCRIPTION
Hi,

the first commit is what I had reported as issue #1 ("MemcachedServers created by CouchbaseMock not working?"), the second one (make http auth optional) is needed so that one can use spymemcached as a client of CouchbaseMock.

What's the preferred way of communication related to this project btw?

Thanx for merging,
cheers,
Martin
