### PR TITLE
upgrade maven plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Keep the entries sorted to reduce the risk for a merge conflict
 *~
+
+# for eclipse
+.classpath
+.project
+
+
 /target/
 /bin/
 /.settings/
 /.idea/workspace.xml
+

--- a/pom.xml
+++ b/pom.xml
@@ -63,15 +63,15 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.7</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.2</version>
+        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
1. maven-resources-plugin 2.2 -> 2.7
2. maven-shade-plugin     1.2 -> 2.2

For Maven 3.2.1 and Java 1.8.0_20, with the original pom configuration, project cannot be packaged, and Eclipse m2e doesn't support version 2.2 of maven-resources-plugin.

So I upgrade these plugins.