### PR TITLE
Expiry time should be calculating without local offset

### DIFF
--- a/src/main/java/org/couchbase/mock/memcached/VBucketStore.java
+++ b/src/main/java/org/couchbase/mock/memcached/VBucketStore.java
@@ -294,14 +294,10 @@ public class VBucketStore {
      * @return The converted value
      */
     public static int convertExpiryTime(int original) {
-        if (original == 0) {
+        if (original == 0 || original > THIRTY_DAYS) {
             return original;
-        } else if (original > THIRTY_DAYS) {
-            return original + (int)Info.getClockOffset();
         }
 
         return (int)((new Date().getTime() / 1000) + original + Info.getClockOffset());
     }
-
-
 }


### PR DESCRIPTION
When we move time in tests we move it for server which calculates and supplies expiry to cocuhbase mock. If couchbase mock adds additional offset, this makes offset doubled. So, offset needs to be applied only when mock calculates expiry date, not when mock takes supplied expiry date.