### PR TITLE
upgrade maven plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Keep the entries sorted to reduce the risk for a merge conflict
 *~
+
+# for eclipse
+.classpath
+.project
+
+
 /target/
 /bin/
 /.settings/
 /.idea/workspace.xml
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.couchbase.mock</groupId>
   <artifactId>CouchbaseMock</artifactId>
@@ -41,7 +42,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>3.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -51,32 +52,46 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.7</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.2</version>
-          <configuration>
-        <archive>
-          <manifest>
-            <mainClass>org.couchbase.mock.CouchbaseMock</mainClass>
-            <packageName>org.couchbase.mock</packageName>
-          </manifest>
-          <manifestEntries>
-            <mode>development</mode>
-            <url>${project.url}</url>
-          </manifestEntries>
-        </archive>
-          </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.couchbase.mock.CouchbaseMock</mainClass>
+              <packageName>org.couchbase.mock</packageName>
+            </manifest>
+            <manifestEntries>
+              <mode>development</mode>
+              <url>${project.url}</url>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.2</version>
+        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -85,7 +100,8 @@
             </goals>
             <configuration>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer"/>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
               </transformers>
               <artifactSet>
                 <excludes>
@@ -101,23 +117,23 @@
     <extensions>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
-         <artifactId>wagon-ssh-external</artifactId>
-         <version>1.0</version>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>1.0</version>
       </extension>
     </extensions>
   </build>
   <dependencies>
-      <dependency>
-          <groupId>com.intellij</groupId>
-          <artifactId>annotations</artifactId>
-          <version>12.0</version>
-      </dependency>
+    <dependency>
+      <groupId>com.intellij</groupId>
+      <artifactId>annotations</artifactId>
+      <version>12.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <version>4.4</version>
     </dependency>
-      <dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -153,17 +169,17 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-    <description>A simple Java mock of Couchbase used for client testing.</description>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <configLocation>config/sun_checks.xml</configLocation>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+  <description>A simple Java mock of Couchbase used for client testing.</description>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+          <configLocation>config/sun_checks.xml</configLocation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
1. maven-resources-plugin (2.2 -> 2.7)
2. maven-shade-plugin     (1.2 -> 2.2)
3. maven-compiler-plugin  (2.0.2 -> 3.1, jdk 1.6 -> jdk 1.8)

For Maven 3.2.1 and Java 1.8.0_20, with the original pom configuration,
project cannot be packaged.Eclipse m2e doesn't support version 2.2 of
maven-resources-plugin. Besides, with version 2.0.2 of maven-compiler-plugin,
compilation failed.

So I upgrade these plugins.
