### PR TITLE
Work-around for https://github.com/couchbase/CouchbaseMock/issues/11

### DIFF
--- a/src/main/java/org/couchbase/mock/Bucket.java
+++ b/src/main/java/org/couchbase/mock/Bucket.java
@@ -425,4 +425,14 @@ public abstract class Bucket {
     public CouchbaseMock getCluster() {
         return cluster;
     }
+
+    public int getCarrierPort() {
+        List<MemcachedServer> aServers =  activeServers();
+        if (aServers.isEmpty()) {
+            throw new RuntimeException("No servers exist for bucket");
+        }
+        MemcachedServer aServer = aServers.get(0);
+        return aServer.getPort();
+    }
+
 }

--- a/src/main/java/org/couchbase/mock/CouchbaseMock.java
+++ b/src/main/java/org/couchbase/mock/CouchbaseMock.java
@@ -261,6 +261,21 @@ public class CouchbaseMock {
     }
 
     /**
+     * Get the carrier port for a bucket.
+     * @param bucketName The bucket name to fetch the carrier port for.
+     * @return The carrier port.
+     */
+    public int getCarrierPort(String bucketName) {
+        Bucket bucket = buckets.get(bucketName);
+        if (null == bucket) {
+            // Buckets are created when the mock is started.  Calling getCarrierPort()
+            // before the mock has been started makes no sense.
+            throw new RuntimeException("Bucket does not exist.  Has the mock been started?");
+        }
+        return bucket.getCarrierPort();
+    }
+
+    /**
      * Get the name of the host to which the REST API is bound
      * @return The bound host
      */

--- a/src/main/java/org/couchbase/mock/CouchbaseMock.java
+++ b/src/main/java/org/couchbase/mock/CouchbaseMock.java
@@ -268,9 +268,9 @@ public class CouchbaseMock {
     public int getCarrierPort(String bucketName) {
         Bucket bucket = buckets.get(bucketName);
         if (null == bucket) {
-            // Buckets are created when the mock is started.  Calling getCarrierPort()
+            // Buckets are created when the mock is started. Calling getCarrierPort()
             // before the mock has been started makes no sense.
-            throw new RuntimeException("Bucket does not exist.  Has the mock been started?");
+            throw new RuntimeException("Bucket does not exist. Has the mock been started?");
         }
         return bucket.getCarrierPort();
     }

--- a/src/test/java/org/couchbase/mock/clientv2/ClientTest.java
+++ b/src/test/java/org/couchbase/mock/clientv2/ClientTest.java
@@ -55,20 +55,7 @@ public class ClientTest extends TestCase {
 
     protected void getPortInfo(String bucket) throws Exception {
         httpPort = couchbaseMock.getHttpPort();
-        URIBuilder builder = new URIBuilder();
-        builder.setScheme("http").setHost("localhost").setPort(httpPort).setPath("mock/get_mcports")
-                .setParameter("bucket", bucket);
-        HttpGet request = new HttpGet(builder.build());
-        HttpClient client = HttpClientBuilder.create().build();
-        HttpResponse response = client.execute(request);
-        int status = response.getStatusLine().getStatusCode();
-        if (status < 200 || status > 300) {
-            throw new ClientProtocolException("Unexpected response status: " + status);
-        }
-        String rawBody = EntityUtils.toString(response.getEntity());
-        JsonObject respObject = JsonUtils.GSON.fromJson(rawBody, JsonObject.class);
-        JsonArray portsArray = respObject.getAsJsonArray("payload");
-        carrierPort = portsArray.get(0).getAsInt();
+        carrierPort = couchbaseMock.getCarrierPort(bucket);
     }
 
     protected void createMock(@NotNull String name, @NotNull String password) throws Exception {


### PR DESCRIPTION
Work-around for https://github.com/couchbase/CouchbaseMock/issues/11.

This allows the carrier port to be fetched from the mock in a more graceful way.