### PR TITLE
Update maven plugins and Relocate shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -69,7 +69,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.2</version>
+        <version>${maven-resources-plugin.version}</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
@@ -77,7 +77,7 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>${maven-jar-plugin.version}</version>
           <configuration>
         <archive>
           <manifest>
@@ -94,7 +94,22 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.2</version>
+        <version>${maven-shade-plugin.version}</version>
+        <configuration>
+          <relocations>
+            <relocation>
+            <pattern>org</pattern>
+            <shadedPattern>com.couchbase.mock.deps.org</shadedPattern>
+          </relocation>
+            <relocation>
+              <pattern>com</pattern>
+              <shadedPattern>com.couchbase.mock.deps.com</shadedPattern>
+              <excludes>
+                <exclude>com.couchbase.mock.*</exclude>
+              </excludes>
+            </relocation>
+          </relocations>
+        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
@@ -118,7 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>${maven-source-plugin.version}</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -131,7 +146,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>${maven-javadoc-plugin.version}</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -212,6 +227,12 @@
   </dependencies>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
+    <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
+    <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
   </properties>
     <description>A simple Java mock of Couchbase used for client testing.</description>
     <reporting>


### PR DESCRIPTION
Update maven plugins:
- maven-compiler-plugin.version 3.8.0
- maven-jar-plugin.version 3.1.0
- maven-shade-plugin.version 3.2.0
- maven-resources-plugin.version 3.1.0

Relocate shaded dependencies into `couchbase.mock` package

@avsej Please review. I've found your commit with revert of plugins update, but I could not find out what was the issue with the change.