### PR TITLE
Fix query server registration

### DIFF
--- a/src/main/java/com/couchbase/mock/CouchbaseMock.java
+++ b/src/main/java/com/couchbase/mock/CouchbaseMock.java
@@ -279,7 +279,7 @@ public class CouchbaseMock {
         userManagementHandler = new UserManagementHandler(this);
         userManagementHandler.register(httpServer);
         httpServer.register("/mock/*", new ControlHandler(controlDispatcher));
-        httpServer.register("/query/*", new QueryServer());
+        httpServer.register("/query*", new QueryServer());
     }
 
     /**


### PR DESCRIPTION
This pull request resolves #55, #54, and #35 .  Essentially, some versions of the Couchbase sdk send query requests to the `/query` endpoint and not `/query/`